### PR TITLE
Fixed wrong <img> HTML tag

### DIFF
--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -43,7 +43,7 @@ widget3:
 permalink: /index.html
 ---
  <center>
-  <img src="images/unibo-seal.png"></img>
+  <img src="images/unibo-seal.png"/>
   <p>Alchemist has been created at University of Bologna by the APICe research group.</p>
  </center>
 


### PR DESCRIPTION
Fixed wrong `<img>` HTML tag usage, that made it show part of the tag ( `</img>` ) next to the Unibo logo. That's because `<img>` is an empty tag in HTML.